### PR TITLE
Fixed Error in tempA[0][1] from 0.0 to 1.0 in edgedetection

### DIFF
--- a/pycnn.py
+++ b/pycnn.py
@@ -115,7 +115,7 @@ class pycnn(object):
 
     def edgedetection(self, inputlocation='', outputlocation='output.png'):
         name = 'Edge detection'
-        tempA = [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+        tempA = [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]]
         tempB = [[-1.0, -1.0, -1.0], [-1.0, 8.0, -1.0], [-1.0, -1.0, -1.0]]
         Ib = -1.0
         # num refers to the number of samples of time points from start = 0 to


### PR DESCRIPTION
In [L118](https://github.com/lostwarrior404/PyCNN/blob/master/pycnn.py#L118) of `PyCNN` `tempA[0][1]` should be 1.0 instead of 0.0 according to [link](http://cnn-technology.itk.ppke.hu/Template_library_v4.0alpha1.pdf) Page 48 
