### PR TITLE
Fix issue 29 oo ode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,9 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+#############
+## Jetbrains PyCharm
+#############
+.idea/
+*.iws

--- a/pycnn.py
+++ b/pycnn.py
@@ -65,7 +65,7 @@ class pycnn(object):
         self.m = 0  # width (number of columns)
         self.n = 0  # height (number of rows)
 
-    def f(self, x, t, Ib, Bu, tempA):
+    def f(self, t, x, Ib, Bu, tempA):
         """Computes the derivative of x at t.
 
         Args:
@@ -135,13 +135,13 @@ class pycnn(object):
         z0 = u * initialcondition
         Bu = sig.convolve2d(u, tempB, 'same')
         z0 = z0.flatten()
-        # ode = sint.ode(self.f, jac=None) \
-        #     .set_integrator("vode", max_step=1000) \
-        #     .set_initial_value(z0) \
-        #     .set_f_params(Ib, Bu, tempA)
-        # ode_result = ode.integrate(t)
-        ode_result = sint.odeint(
-            self.f, z0, t, args=(Ib, Bu, tempA), mxstep=1000)
+        ode = sint.ode(self.f, jac=None) \
+            .set_integrator("vode", max_step=1000) \
+            .set_initial_value(z0) \
+            .set_f_params(Ib, Bu, tempA)
+        ode_result = ode.integrate(t)
+        # ode_result = sint.odeint(
+        #     self.f, z0, t, args=(Ib, Bu, tempA), mxstep=1000)
         # if ode.successful():
         #     print("It worked!")
         # else:

--- a/pycnn.py
+++ b/pycnn.py
@@ -135,18 +135,20 @@ class pycnn(object):
         z0 = u * initialcondition
         Bu = sig.convolve2d(u, tempB, 'same')
         z0 = z0.flatten()
-        ode = sint.ode(self.f, jac=None)\
-            .set_integrator("lsoda", max_step=1000)\
-            .set_initial_value(z0)\
-            .set_f_params(Ib, Bu, tempA)
-        ode_result = ode.integrate(t)
-        # ode_result = sint.odeint(
-        #     self.f, z0, t, args=(Ib, Bu, tempA), mxstep=1000)
+        # ode = sint.ode(self.f, jac=None) \
+        #     .set_integrator("vode", max_step=1000) \
+        #     .set_initial_value(z0) \
+        #     .set_f_params(Ib, Bu, tempA)
+        # ode_result = ode.integrate(t)
+        ode_result = sint.odeint(
+            self.f, z0, t, args=(Ib, Bu, tempA), mxstep=1000)
         # if ode.successful():
         #     print("It worked!")
         # else:
         #    print("Nope. Didn't work.")
         z = self.cnn(ode_result)
+        print(z.shape)
+        return
         l = z[z.shape[0] - 1, :].reshape((self.n, self.m))
         l = l / (255.0)
         l = np.uint8(np.round(l * 255))

--- a/pycnn.py
+++ b/pycnn.py
@@ -135,13 +135,13 @@ class pycnn(object):
         z0 = u * initialcondition
         Bu = sig.convolve2d(u, tempB, 'same')
         z0 = z0.flatten()
-        # ode = sint.ode(self.f,jac=None)\
-        #     .set_integrator("lsoda", max_step=1000)\
-        #     .set_initial_value(z0)\
-        #     .set_f_params(Ib, Bu, tempA)
-        # ode_result = ode.integrate(t)
-        ode_result = sint.odeint(
-            self.f, z0, t, args=(Ib, Bu, tempA), mxstep=1000)
+        ode = sint.ode(self.f, jac=None)\
+            .set_integrator("lsoda", max_step=1000)\
+            .set_initial_value(z0)\
+            .set_f_params(Ib, Bu, tempA)
+        ode_result = ode.integrate(t)
+        # ode_result = sint.odeint(
+        #     self.f, z0, t, args=(Ib, Bu, tempA), mxstep=1000)
         # if ode.successful():
         #     print("It worked!")
         # else:

--- a/pycnn.py
+++ b/pycnn.py
@@ -143,7 +143,7 @@ class pycnn(object):
         if ode.successful():
             print("It worked!")
         else:
-            print("Nope.")
+            print("Nope. Didn't work.")
         z = self.cnn(ode_result)
         l = z[z.shape[0] - 1, :].reshape((self.n, self.m))
         l = l / (255.0)

--- a/pycnn.py
+++ b/pycnn.py
@@ -135,15 +135,17 @@ class pycnn(object):
         z0 = u * initialcondition
         Bu = sig.convolve2d(u, tempB, 'same')
         z0 = z0.flatten()
-        ode = sint.ode(self.f)
-        ode.set_integrator("lsoda", max_step=1000)
-        ode.set_initial_value(z0)
-        ode.set_f_params(Ib, Bu, tempA)
-        ode_result = ode.integrate(t)
-        if ode.successful():
-            print("It worked!")
-        else:
-            print("Nope. Didn't work.")
+        #ode = sint.ode(self.f,jac=None)\
+        #    .set_integrator("lsoda", max_step=1000)\
+        #    .set_initial_value(z0)\
+        #    .set_f_params(Ib, Bu, tempA)
+        #ode_result = ode.integrate(t)
+        ode_result = sint.odeint(
+            self.f, z0, t, args=(Ib, Bu, tempA), mxstep=1000)
+        #if ode.successful():
+        #    print("It worked!")
+        #else:
+        #    print("Nope. Didn't work.")
         z = self.cnn(ode_result)
         l = z[z.shape[0] - 1, :].reshape((self.n, self.m))
         l = l / (255.0)

--- a/pycnn.py
+++ b/pycnn.py
@@ -135,8 +135,16 @@ class pycnn(object):
         z0 = u * initialcondition
         Bu = sig.convolve2d(u, tempB, 'same')
         z0 = z0.flatten()
-        z = self.cnn(sint.odeint(
-            self.f, z0, t, args=(Ib, Bu, tempA), mxstep=1000))
+        ode = sint.ode(self.f)
+        ode.set_integrator("lsoda", max_step=1000)
+        ode.set_initial_value(z0)
+        ode.set_f_params(Ib, Bu, tempA)
+        ode_result = ode.integrate(t)
+        if ode.successful():
+            print("It worked!")
+        else:
+            print("Nope.")
+        z = self.cnn(ode_result)
         l = z[z.shape[0] - 1, :].reshape((self.n, self.m))
         l = l / (255.0)
         l = np.uint8(np.round(l * 255))

--- a/pycnn.py
+++ b/pycnn.py
@@ -135,16 +135,16 @@ class pycnn(object):
         z0 = u * initialcondition
         Bu = sig.convolve2d(u, tempB, 'same')
         z0 = z0.flatten()
-        #ode = sint.ode(self.f,jac=None)\
-        #    .set_integrator("lsoda", max_step=1000)\
-        #    .set_initial_value(z0)\
-        #    .set_f_params(Ib, Bu, tempA)
-        #ode_result = ode.integrate(t)
+        # ode = sint.ode(self.f,jac=None)\
+        #     .set_integrator("lsoda", max_step=1000)\
+        #     .set_initial_value(z0)\
+        #     .set_f_params(Ib, Bu, tempA)
+        # ode_result = ode.integrate(t)
         ode_result = sint.odeint(
             self.f, z0, t, args=(Ib, Bu, tempA), mxstep=1000)
-        #if ode.successful():
-        #    print("It worked!")
-        #else:
+        # if ode.successful():
+        #     print("It worked!")
+        # else:
         #    print("Nope. Didn't work.")
         z = self.cnn(ode_result)
         l = z[z.shape[0] - 1, :].reshape((self.n, self.m))

--- a/pycnn.py
+++ b/pycnn.py
@@ -79,20 +79,6 @@ class pycnn(object):
         dx = -x + Ib + Bu + sig.convolve2d(self.cnn(x), tempA, 'same')
         return dx.reshape(self.m * self.n)
 
-    def f_old(self, x, t, Ib, Bu, tempA):
-        """Computes the derivative of x at t.
-
-        Args:
-            x: The input.
-            Ib (float): System bias.
-            Bu: Convolution of control template with input.
-            tempA (:obj:`list` of :obj:`list`of :obj:`float`): Feedback
-                template.
-        """
-        x = x.reshape((self.n, self.m))
-        dx = -x + Ib + Bu + sig.convolve2d(self.cnn(x), tempA, 'same')
-        return dx.reshape(self.m * self.n)
-
     def cnn(self, x):
         """Piece-wise linear sigmoid function.
 
@@ -151,7 +137,7 @@ class pycnn(object):
         z0 = z0.flatten()
         t_final = t.max()
         t_initial = t.min()
-        dt = t[1]-t[0]
+        dt = t[1] - t[0]
         ode = sint.ode(self.f) \
             .set_integrator("vode") \
             .set_initial_value(z0, t_initial) \


### PR DESCRIPTION
This is to add scipy.integrate.ode to the project and allow for the more object-oriented friendly ODE instead of the previous scipy.integrate.odeint functionality.

This should resolve Issue #29.

I made some other modifications to allow for the new ode function.

You can see that this passes all tests found here: [https://codecov.io/gh/pjbollinger/PyCNN/commit/52dc7e8b60d0df1a586a674670599af08cef1bd9](https://codecov.io/gh/pjbollinger/PyCNN/commit/52dc7e8b60d0df1a586a674670599af08cef1bd9)
